### PR TITLE
Minor edits

### DIFF
--- a/docs-src/zdm-core/modules/migrate/nav.adoc
+++ b/docs-src/zdm-core/modules/migrate/nav.adoc
@@ -1,7 +1,7 @@
 * xref:migration-introduction.adoc[Migrating]
 ** xref:migration-faqs.adoc[FAQs]
 ** xref:migration-infrastructure.adoc[Deployment considerations]
-** xref:migration-tls.adoc[SSL Transport Layer Security]
+** xref:migration-tls.adoc[Configure Transport Layer Security]
 ** xref:migration-prepare-environment.adoc[Prepare your existing environment for migration]
 ** xref:migration-create-target.adoc[Create target environment for migration]
 ** xref:migration-run-ansible-playbooks.adoc[Setup and run Ansible playbooks]

--- a/docs-src/zdm-core/modules/migrate/pages/migration-faqs.adoc
+++ b/docs-src/zdm-core/modules/migrate/pages/migration-faqs.adoc
@@ -77,7 +77,7 @@ All the {company} {zdm-product} GitHub repos are public. You are welcome to read
 
 * https://github.com/datastax/migration-docs[Migration documentation^] repo.
 
-== Does ZDM Proxy support SSL Transport Layer Security (TLS)? 
+== Does ZDM Proxy support Transport Layer Security (TLS)? 
 
 Yes, and here's a summary:
 

--- a/docs-src/zdm-core/modules/migrate/pages/migration-tls.adoc
+++ b/docs-src/zdm-core/modules/migrate/pages/migration-tls.adoc
@@ -1,6 +1,6 @@
-= Configure SSL Transport Layer Security (TLS)
+= Configure Transport Layer Security (TLS)
 
-{zdm-proxy} supports connections with SSL/TLS. 
+{zdm-proxy} supports connections with TLS. 
 
 == Introduction
 


### PR DESCRIPTION
TLS is the successor to SSL, so removed the SSL/TLS qualifier ... just talk about TLS.