### PR TITLE
Update "connect to proxy" pseudocode to include credentials

### DIFF
--- a/docs-src/zdm-core/modules/migrate/pages/migration-connect-clients-to-proxy.adoc
+++ b/docs-src/zdm-core/modules/migrate/pages/migration-connect-clients-to-proxy.adoc
@@ -26,7 +26,7 @@ Perhaps the simplest way to demonstrate how to use the DataStax drivers to conne
 // Create an object to represent a Cassandra cluster listening for connections at
 // 10.20.30.40 on the default port (9042).  The username and password are necessary
 // only if your Cassandra cluster has authentication enabled.
-Cluster my_cluster = Cluster.build_new_cluster(contact_points = “10.20.30.40”, username="myuser", password="mypassword")
+Cluster my_cluster = Cluster.build_new_cluster(contact_points = “10.20.30.40”, username="myusername", password="mypassword")
 
 // Connect our Cluster object to our Cassandra cluster, returning a Session
 Session my_session = my_cluster.connect()


### PR DESCRIPTION
This PR shouldn't be merged until we make sure it's usage matches the pseudocode in the "connect to Astra" page.  That content is currently under review in https://github.com/datastax/migration-docs/pull/78.