### PR TITLE
More readability improvements after several discussions

### DIFF
--- a/docs-src/zdm-core/modules/migrate/pages/connect-clients-to-target.adoc
+++ b/docs-src/zdm-core/modules/migrate/pages/connect-clients-to-target.adoc
@@ -28,29 +28,24 @@ To connect to your Astra DB cluster, you will need:
 ** There is one SCB for each Astra DB cluster (or one for each region of an Astra DB Multi-region cluster).
 ** The SCB **does not contain** your DB credentials.
 
-The SCB can be downloaded from the Astra Portal as follows:
+include::partial$tip-scb.adoc[]
 
-. From your Dashboard page in Astra Portal, select your database.
-. On the Overview page, select Connect.
-. In the **Select a Method** section, select Drivers and then Legacy from the dropdown menu to select your driver type from the list to load language-specific instructions.
-. Click **Download Bundle**.
-. The `secure-connect-database_name.zip` file is downloaded to your machine.
+You will also need to check whether the driver used by your client application has native support for the xref:glossary.adoc#_secure_connect_bundle_scb[Astra DB Secure Connect Bundle]. To do so, please refer to the documentation for your driver language and version,
+and check the per-language https://docs.datastax.com/en/driver-matrix/docs/version-compatibility.html[driver compatibility matrix^] for details (look for the support status in the **Astra / Cloud** column for your driver version).
 
-You will also need to check whether the driver used by your client application has native support for the xref:glossary.adoc#_secure_connect_bundle_scb[Astra DB Secure Connect Bundle]. To do so, please refer to the documentation for your driver language and version.
-
-The SCB support was made available beginning the following versions in the drivers:
-
-* https://docs.datastax.com/en/developer/cpp-driver/latest/changelog/#2-14-0[Beginning `2.14.0` of {company} C++ Driver^].
-
-* https://docs.datastax.com/en/developer/csharp-driver/latest/changelog/#3-12-0[Beginning `3.12.0` of {company} C\# Driver^]
-
-* https://docs.datastax.com/en/developer/java-driver/latest/changelog/#3-8-0[Beginning `3.8.0` & `4.3.0` of {company} Java Driver^].
-
-* https://github.com/datastax/nodejs-driver/blob/master/CHANGELOG.md#440[Beginning `4.4.0` of {company} Nodejs Driver^].
-
-* https://docs.datastax.com/en/developer/python-dse-driver/latest/CHANGELOG/#id24[Beginning `2.11.0` & `3.20.0` of {company} Python Driver^].
-
-Based on this, follow the instructions in the relevant section below.
+// The SCB support was made available beginning the following versions in the drivers:
+// 
+// * https://docs.datastax.com/en/developer/cpp-driver/latest/changelog/#2-14-0[Beginning `2.14.0` of {company} C++ Driver^].
+// 
+// * https://docs.datastax.com/en/developer/csharp-driver/latest/changelog/\#3-12-0[Beginning `3.12.0` of {company} C# Driver^]
+// 
+// * https://docs.datastax.com/en/developer/java-driver/latest/changelog/#3-8-0[Beginning `3.8.0` & `4.3.0` of {company} Java Driver^].
+// 
+// * https://github.com/datastax/nodejs-driver/blob/master/CHANGELOG.md#440[Beginning `4.4.0` of {company} Nodejs Driver^].
+// 
+// * https://docs.datastax.com/en/developer/python-dse-driver/latest/CHANGELOG/#id24[Beginning `2.11.0` & `3.20.0` of {company} Python Driver^].
+// 
+// Based on this, follow the instructions in the relevant section below.
 
 [TIP]
 ====

--- a/docs-src/zdm-core/modules/migrate/pages/create-target.adoc
+++ b/docs-src/zdm-core/modules/migrate/pages/create-target.adoc
@@ -55,20 +55,20 @@ For more information about role permissions, see link:https://docs.datastax.com/
 
 === Get the Secure Connect Bundle and upload to client instances
 
-Your cluster's Secure Connect Bundle (SCB) will be needed by:
+Your cluster's xref:glossary.adoc#_secure_connect_bundle_scb[Secure Connect Bundle] (SCB) is a zip file that contains the TLS encryption certificates and other metadata to connect to your database.
+It will be needed by:
 
 * Your client application, to connect directly to Astra DB near the end of the migration;
 * Cassandra Data Migrator or DSBulk Migrator, to migrate and validate data into Astra DB.
 
+Note that the credentials are **not contained** in the SCB.
+
 // * The {company} Bulk Migrator to import the existing data into Astra
 
-With the Astra DB database in an **Active** status, download its SCB from Astra Portal. It's a zip file that contains the TLS encryption certificates and other metadata to connect to your database. Note that the credentials are not contained in the SCB.
+include::partial$tip-scb.adoc[]
 
-. In Astra Portal, go to the Dashboard and select the serverless database that you created in the prior step.
-. Click on **Connect**.
-. Select the **Java driver** and click on **Download bundle**.
-. Copy the SCB to your client application instance:
-+
+To copy the SCB to your client application instance, use `scp`:
+
 [source,bash]
 ----
 scp -i <your_ssh_key> secure-connect-<target cluster name>.zip ubuntu@<public IP of client application instance>:

--- a/docs-src/zdm-core/modules/migrate/pages/glossary.adoc
+++ b/docs-src/zdm-core/modules/migrate/pages/glossary.adoc
@@ -46,7 +46,7 @@ See xref:glossary.adoc#_asynchronous_dual_reads[async dual reads].
 
 == Secure Connect Bundle (SCB)
 
-A ZIP file generated in https://astra.datastax.com[Astra Portal^] that contains connection metadata and TLS encryption certificates (but never your credentials) for your Astra DB database. For details, see https://docs.datastax.com/en/astra-serverless/docs/connect/secure-connect-bundle.html[Working with the Secure Connect Bundle^].
+A ZIP file generated in https://astra.datastax.com[Astra Portal^] that contains connection metadata and TLS encryption certificates (but not the database credentials) for your Astra DB database. For details, see https://docs.datastax.com/en/astra-serverless/docs/connect/secure-connect-bundle.html[Working with the Secure Connect Bundle^].
 
 [[target]]
 == Target

--- a/docs-src/zdm-core/modules/migrate/pages/manage-proxy-instances.adoc
+++ b/docs-src/zdm-core/modules/migrate/pages/manage-proxy-instances.adoc
@@ -52,14 +52,14 @@ To confirm that the {zdm-proxy} instances are operating normally, or investigate
 
 === View the logs
 
-The {zdm-proxy} runs as a Docker container on each proxy host. Its logs can be viewed by connecting to a proxy host and running the following command:
+The {zdm-proxy} runs as a Docker container on each proxy host. Its logs can be viewed by connecting to a proxy host and running the following command (remember on these machines Docker is available to superusers):
 
 [source,bash]
 ----
 sudo docker container logs zdm-proxy-container
 ----
 
-To leave the logs open and continuously output the latest log messages, append the `--follow` option to the command above.
+To leave the logs open and continuously output the latest log messages, append the `--follow` (or `-f`) option to the command above.
 
 === Collect the logs
 

--- a/docs-src/zdm-core/modules/migrate/pages/setup-ansible-playbooks.adoc
+++ b/docs-src/zdm-core/modules/migrate/pages/setup-ansible-playbooks.adoc
@@ -116,7 +116,7 @@ The {zdm-utility} will validate each variable that you enter. In case of invalid
 You have five attempts to enter valid variables. You can always run the {zdm-utility} again, if necessary.
 ====
 
-. Enter the path to, and name, of the SSH private key to access the proxy hosts. Example:
+. Enter the path to, and name of, the SSH private key to access the proxy hosts. Example:
 +
 [source,bash]
 ----

--- a/docs-src/zdm-core/modules/migrate/pages/troubleshooting-scenarios.adoc
+++ b/docs-src/zdm-core/modules/migrate/pages/troubleshooting-scenarios.adoc
@@ -261,7 +261,10 @@ ERRO[0076] Client Handler could not be created: ORIGIN-CONNECTOR context timed o
 {zdm-proxy} has connectivity only to a subset of the nodes.
 
 The control connection (during {zdm-proxy} startup) cycles through the nodes until it finds one that can be connected to.
-For client connections, the proxy cycles through the "assigned nodes" only (which could have been discovered, they might not be in the contact points).
+For client connections, each proxy instance cycles through its "assigned nodes" only.
+_(The "assigned nodes" are a different subset of the cluster nodes for each proxy instance,
+generally non-overlapping between proxy instances so as to avoid any interference with the load balancing already in place at client-side driver level.
+The assigned nodes are not necessarily contact points: even discovered nodes undergo assignment to proxy instances.)_
 
 In the example above, the {zdm-proxy} doesn't have connectivity to 10.0.63.20, which was chosen as the origin node for the incoming client connection, but it was able to connect to 10.0.63.163 during startup.
 

--- a/docs-src/zdm-core/modules/migrate/pages/troubleshooting-tips.adoc
+++ b/docs-src/zdm-core/modules/migrate/pages/troubleshooting-tips.adoc
@@ -4,10 +4,15 @@ Refer to the tips on this page for information that can help you troubleshoot is
 
 == How to retrieve {zdm-proxy} log files
 
-If {zdm-proxy} was deployed using the {zdm-automation}, the automation contains an Ansible playbook that retrieves the logs. For details, see the next xref:troubleshooting-tips.adoc#how-to-view-retrieve-logs[troubleshooting tip].
+Depending on how you deployed {zdm-proxy}, there may be different ways to access
+the logs.
+If you used the {zdm-automation}, see xref:manage-proxy-instances.adoc#_view_the_logs[View the logs] for a quick way
+to view the logs of a single proxy instance.
+Follow the instructions on xref:manage-proxy-instances.adoc#_collect_the_logs[Collect the logs],
+instead, for a playbook that systematically retrieves all logs by all instances and packages them in a zip archive for later inspection.
 
-If you did not use the {zdm-automation}, the steps to retrieve the logs depends on how you deployed the {zdm-proxy}. If
-Docker is used, enter the following command to export the logs of a container to a file:
+If you did not use the {zdm-automation}, you might have to access the logs differently.
+If Docker is used, enter the following command to export the logs of a container to a file:
 
 [source,bash]
 ----
@@ -23,27 +28,6 @@ You may need to use `sudo` to run the `docker` command.
 ====
 Keep in mind that docker logs are deleted if the container is recreated.
 ====
-
-[#how-to-view-retrieve-logs]
-== How to retrieve the {zdm-proxy} logs using the {zdm-automation}
-
-When deployed through the {zdm-automation}, each {zdm-proxy} instance runs as a Docker container. You can view its logs by connecting to the proxy machine and running the following command:
-
-[source,bash]
-----
-sudo docker container logs zdm-proxy-container
-----
-
-You can retrieve logs of all proxy instances using a dedicated playbook: `collect_zdm_proxy_logs.yml`.
-
-If you are using the jumphost as your Ansible control host, no configuration changes are necessary. You can view the playbook's configuration values in `vars/zdm_proxy_log_collection_config.yml`. All default values are fine in most cases:
-
-[source,bash]
-----
-ansible-playbook collect_proxy_logs.yml -i zdm_ansible_inventory
-----
-
-This playbook creates a single zip file, called `zdm_proxy_logs_<current_timestamp>.zip`, in the desired directory (this defaults to `/home/ubuntu/zdm_proxy_archived_logs` in the Ansible Control Host container). This zip file contains the logs from all proxy instances.
 
 == What to look for in the logs
 

--- a/docs-src/zdm-core/modules/migrate/pages/troubleshooting.adoc
+++ b/docs-src/zdm-core/modules/migrate/pages/troubleshooting.adoc
@@ -1,6 +1,6 @@
 = Troubleshooting
 
-Welcome to the {zdm-product} (ZDM) troubleshooting topics. We've organized the descriptions this way:
+The troubleshooting information for {zdm-product} is organized as follows:
 
 * xref:troubleshooting-tips.adoc[] - general advice and some common issues you may encounter.
 * xref:troubleshooting-scenarios.adoc[] - specific descriptions of error conditions, and advice on how to solve the issues.

--- a/docs-src/zdm-core/modules/migrate/partials/tip-scb.adoc
+++ b/docs-src/zdm-core/modules/migrate/partials/tip-scb.adoc
@@ -1,0 +1,11 @@
+[TIP]
+--
+The SCB can be downloaded from the Astra Portal as follows:
+
+. In the Astra Portal, go to the Dashboard and select the serverless database that you created in the prior step. Ensure it is in `Active` state.
+. Click on **Connect**.
+. Select the **Java driver**, choosing the driver based on the CQL APIs.
+. Click on **Download bundle** (choosing a region if prompted to do so).
+
+For more information on the SCB and how to retrieve it, see https://docs.datastax.com/en/astra-serverless/docs/connect/drivers/legacy-drivers.html#_working_with_secure_connect_bundle[the Astra documentation^].
+--


### PR DESCRIPTION
More rephrasings, readability improvements, redundancy removals etc,
including creation of a "partial" about the SCB to easily keep up with the likely
upcoming changes in how the Astra UI offers the bundle.

```
setup-ansible-playbooks       syntax/punctuation;
manage-proxy-instances        reminder about 'sudo docker' here as well;
                              added `-f` as alias to `--follow` do docker logs
create-target                 better bundle explanation and instructions
                              factored SCB instructions in a partial (TIP box)
connect-clients-to-target     aligned with the SCB instructions;
                              defer to published driver compatib.matrix
tip-scp                       'partial' about SCB: no mention of 'legacy'
                              (it could scare users and might disappear from UI)
glossary                      clearer language on credentials not in scb
troubleshooting               less informal intro paragraph for consistence
troubleshooting-tips          rephrased bits about the log collection;
                              references to 'manage-proxy-instances';
                              removed a redundanct section.
troubleshooting-scenarios     short definition of "assigned nodes".
```