### PR TITLE
Updated version numbers in cassandra-data-migrator and development-in…

### DIFF
--- a/docs-src/zdm-core/modules/migrate/pages/cassandra-data-migrator.adoc
+++ b/docs-src/zdm-core/modules/migrate/pages/cassandra-data-migrator.adoc
@@ -6,16 +6,16 @@ Use {cstar-data-migrator} to migrate and validate tables between Origin and Targ
 == {cstar-data-migrator} prerequisites
 
 * Install or switch to Java 8. The Spark binaries are compiled with this version of Java.
-* Install https://archive.apache.org/dist/spark/spark-3.3.1/[Spark 3.3.1^] on a single VM (no cluster necessary) where you want to run this job. 
-* Optionally, install https://maven.apache.org/download.cgi[Maven^] 3.8.x, if you want to build the JAR for local development.
+* Install https://archive.apache.org/dist/spark/spark-3.4.1/[Spark 3.4.1^] on a single VM (no cluster necessary) where you want to run this job. 
+* Optionally, install https://maven.apache.org/download.cgi[Maven^] 3.9.x, if you want to build the JAR for local development.
 
 You can install Apache Spark by running the following commands:
 
 [source,bash]
 ----
-wget https://archive.apache.org/dist/spark/spark-3.3.1/spark-3.3.1-bin-hadoop3.tgz 
+wget https://archive.apache.org/dist/spark/spark-3.4.1/spark-3.4.1-bin-hadoop3.tgz 
 
-tar -xvzf spark-3.3.1-bin-hadoop3.tgz
+tar -xvzf spark-3.4.1-bin-hadoop3.tgz
 ----
 
 [[cdm-install-as-container]]
@@ -38,7 +38,7 @@ Version 4.x of {cstar-data-migrator} is not backward-compatible with `*.properti
 [[cdm-build-jar-local]]
 == Build {cstar-data-migrator} JAR for local development (optional)
 
-Optionally, you can build the {cstar-data-migrator} JAR for local development. (You'll need https://maven.apache.org/download.cgi[Maven^] 3.8.x.)
+Optionally, you can build the {cstar-data-migrator} JAR for local development. (You'll need https://maven.apache.org/download.cgi[Maven^] 3.9.x.)
 
 Example:
 

--- a/docs-src/zdm-core/modules/migrate/pages/deployment-infrastructure.adoc
+++ b/docs-src/zdm-core/modules/migrate/pages/deployment-infrastructure.adoc
@@ -43,7 +43,7 @@ We will use the term "machine" to indicate a cloud instance (on any cloud provid
 * 1-M machines to run either {dsbulk-migrator} or {cstar-data-migrator}.
 ** It's recommended that you start with at least one VM with 16 vCPUs and 64GB RAM and a minimum of 200GB storage. Depending on the total amount of data that is planned for migration, more than one VM may be needed.
 ** Requirements:
-*** Ubuntu Linux 18.04 or newer
+*** Ubuntu Linux 20.04 or newer, RedHat Family Linux 7 or newer
 *** 16 vCPUs
 *** 64GB RAM
 *** 200GB - 2TB storage (if you use dsbulk-migrator to unload multiple terabytes of data from origin, then load into target, you may need to consider more space to accommodate the data that needs to be staged)


### PR DESCRIPTION
Updated version numbers in cassandra-data-migrator and development-infrastructure. See [coppi](https://coppi.aws.dsinternal.org/en/DOC-4082/docs/migrate/cassandra-data-migrator.html) build.