### PR TITLE
Fix rendering of a (sub) bullet point on deploy-proxy-monitoring page

### DIFF
--- a/modules/ROOT/pages/deploy-proxy-monitoring.adoc
+++ b/modules/ROOT/pages/deploy-proxy-monitoring.adoc
@@ -100,7 +100,7 @@ Leave blank if authentication is not enabled on the cluster.
 ... Specify its path in `*_astra_secure_connect_bundle_path`.
 .. Otherwise, if you wish the automation to download the cluster's Secure Connect Bundle for you, just specify the two following variables:
 ... `*_astra_db_id`: the cluster's https://docs.datastax.com/en/astra/astra-db-vector/faqs.html#where-do-i-find-the-organization-id-database-id-or-region-id[database id].
-... `*_astra_token`: the token value from an {astra-db} application token with the *Read/Write User* role, prefixed by `AstraCS:`.
+... `*_astra_token`: the token value from an {astra-db} application token with the **Read/Write User** role, prefixed by `AstraCS:`.
 
 Save the file and exit the editor.
 


### PR DESCRIPTION
Check out point `3.b.ii`:

Before:

![before](https://github.com/user-attachments/assets/1f54ed66-a446-419a-9df6-99a3fe395f90)

After:

![after](https://github.com/user-attachments/assets/b1c1faa0-5d11-435f-999b-608cdfb55895)
