### PR TITLE
DOC-5249 - Update DSE migration tool paths and fix link

### DIFF
--- a/modules/ROOT/pages/dse-migration-paths.adoc
+++ b/modules/ROOT/pages/dse-migration-paths.adoc
@@ -48,7 +48,7 @@ If your target database isn't directly compatible with a migration from {dse-sho
 
 == Migrate your code
 
-In the case of a platform migration where you want to shift your applications to use your new databases, migrate your data first, and then update your code to connect exclusively to the new databases.
+In the case of a platform migration where you want to shift your applications to use your new databases, migrate your data first, and then update your client applications to connect exclusively to the new databases.
 
 If you are already using a xref:datastax-drivers:compatibility:driver-matrix.adoc[compatible {cass-short} driver], you can modify the driver connection string to connect to the new databases.
 For some migrations, changing the connection string might be the only change you need to make to your code.

--- a/modules/ROOT/pages/dse-migration-paths.adoc
+++ b/modules/ROOT/pages/dse-migration-paths.adoc
@@ -5,39 +5,33 @@ The {dse} migration toolkit includes the xref:ROOT:components.adoc[{company} mig
 
 This documentation doesn't describe _all_ possible migration paths; it focuses on migrations using {company} migration tools like {product-proxy}.
 
+[TIP]
+====
+Whenever possible, {company} recommends using the {product} ({product-short}) tools when you need to maintain live traffic for your applications while transferring data.
+This is most relevant for full-scale platform migrations where you move your data _and_ switch your applications to connect to your new databases.
+
+The {product-short} tools orchestrate and synchronize read/write requests while you use a data migration tool to copy data from one cluster to the other.
+Then, you can take as much time as you need to validate the data and simulate production workloads on your new cluster before updating your application code to use the new databases.
+
+For information about clusters that support the {product-short} tools, including supported {dse-short} versions, see xref:ROOT:zdm-proxy-migration-paths.adoc[].
+====
+
 == Migrate your data
 
 The tools and process for data migration to or from {dse-short} depends on your {dse-short} version and the other database's platform or version.
-
-[TIP]
-====
-For information about clusters that are eligible for {product} to or from {dse-short}, see xref:ROOT:zdm-proxy-migration-paths.adoc[].
-====
 
 [tabs]
 ======
 Migrate data to {dse-short}::
 +
 --
-The following information provides guidance on migrations _to_ {dse-short}.
+The following information provides guidance on migrations _to_ {dse-short}, with a focus on data transfer tools:
 
-Generally, {company} recommends migrating to the latest version of {dse-short}, unless you have a compatibility issue that requires an interim migration to an earlier version before upgrading.
+* xref:6.9@dse:managing:operations/migrate-data.adoc[Migrate to {dse-short} 6.9]
+* xref:6.8@dse:managing:operations/migrate-data.adoc[Migrate to {dse-short} 6.8]
+* xref:5.1@dse:managing:operations/migrate-data.adoc[Migrate to {dse-short} 5.1]
 
-//TODO: Resolve DSE topic duplication and replace these at the source with one summary page that points to here.
-
-* {dse-short} 6.9
-+
-** xref:6.9@dse:tooling:migration-path-dse.adoc[{dse-short} 6.9 migration tools]
-** xref:6.9@dse:managing:operations/migrate-data.adoc[Migrate data to {dse-short} 6.9]
-
-* {dse-short} 6.8
-+
-** xref:6.8@dse:tooling:migration-path-dse.adoc[{dse-short} 6.8 migration tools]
-** xref:6.8@dse:managing:operations/migrate-data.adoc[Migrate data to {dse-short} 6.8]
-
-* {dse-short} 5.1
-+
-** xref:5.1@dse:managing:operations/migrate-data.adoc[Migrate data to {dse-short} 5.1]
+Generally, {company} recommends migrating to the latest version of {dse-short}, unless you have a specific functional requirement or a compatibility issue that requires migrating to an earlier version.
 --
 
 Migrate data from {dse-short}::
@@ -46,13 +40,15 @@ Migrate data from {dse-short}::
 When migrating _from_ {dse-short} to another {cass-short}-based database, follow the migration guidance for your target database to determine cluster compatibility, migration options, and recommendations.
 For example, for {astra-db}, see xref:ROOT:astra-migration-paths.adoc[], and for {hcd-short}, see xref:ROOT:hcd-migration-paths.adoc[].
 
-If your target database isn't directly compatible with a migration from {dse-short}, you might need to take interim steps to prepare your data for migration, such as upgrading your {dse-short} version or modifying the data in your existing database to be compatible with the target database.
+For information about source and target clusters that are supported by the {product-short} tools, see xref:ROOT:zdm-proxy-migration-paths.adoc[].
+
+If your target database isn't directly compatible with a migration from {dse-short}, you might need to take interim steps to prepare your data for migration, such as upgrading your {dse-short} version, modifying the data in your existing database to be compatible with the target database, or running an extract, transform, load (ETL) pipeline.
 --
 ======
 
 == Migrate your code
 
-After migrating your data, your applications can connect exclusively to your new databases.
+In the case of a platform migration where you want to shift your applications to use your new databases, migrate your data first, and then update your code to connect exclusively to the new databases.
 
 If you are already using a xref:datastax-drivers:compatibility:driver-matrix.adoc[compatible {cass-short} driver], you can modify the driver connection string to connect to the new databases.
 For some migrations, changing the connection string might be the only change you need to make to your code.

--- a/modules/ROOT/pages/hcd-migration-paths.adoc
+++ b/modules/ROOT/pages/hcd-migration-paths.adoc
@@ -25,7 +25,7 @@ During the {product-short} process, you use a xref:ROOT:migrate-and-validate-dat
 
 {company} recommends that you do the following:
 
-* Choose a data migration tool that also includes strong validation capabilities, such as [{cass-migrator} ({cass-migrator-short})].
+* Choose a data migration tool that also includes strong validation capabilities, such as xref:ROOT:cassandra-data-migrator.adoc[{cass-migrator} ({cass-migrator-short})].
 * Be aware of incompatible data types that can fail to migrate from your old cluster.
 //For example, {hcd-short} 1.2.3 doesn't support tuples in {dse-short} versions 6.8.4 and earlier.
 


### PR DESCRIPTION
Goes with https://github.com/riptano/dse-docs-new/pull/396 and others

Update the DSE migration paths page in the migration docs to highlight ZDM and remove redundant links.

Preview: https://d5rxiv0do0q3v.cloudfront.net/doc-5249-3/data-migration/dse-migration-paths.html