### PR TITLE
DOC-5749 add specific token permissions for sideloader

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -64,3 +64,7 @@ asciidoc:
     # Astra role attributes (compare with astra-vector-docs antora.yml)
     database-administrator-role: 'xref:astra-db-serverless:administration:rbac.adoc#database-administrator-role[Database Administrator]'
     read-write-user-role: 'xref:astra-db-serverless:administration:rbac.adoc#read-write-user-role[Read/Write User]'
+
+    # Astra permission attributes (compare with astra-vector-docs antora.yml)
+    create-db-permission: 'xref:astra-db-serverless:administration:rbac.adoc#create-db-permission[Create DB]'
+    view-db-permission: 'xref:astra-db-serverless:administration:rbac.adoc#view-db-permission[View DB]'

--- a/modules/sideloader/pages/migrate-sideloader.adoc
+++ b/modules/sideloader/pages/migrate-sideloader.adoc
@@ -233,10 +233,16 @@ See xref:astra-db-serverless:databases:database-limits.adoc[] for more informati
 [source,bash,subs="+quotes"]
 ----
 export dbID=*DATABASE_ID*
-export token=*TOKEN*
+export token=*APPLICATION_TOKEN*
 ----
 +
-Replace *`DATABASE_ID`* with the xref:astra-db-serverless:databases:create-database.adoc#get-db-id[database ID], and replace *`TOKEN`* with an xref:astra-db-serverless:administration:manage-application-tokens.adoc[application token] with the {database-administrator-role} role.
+Replace the following:
++
+--
+*`DATABASE_ID`*: The xref:astra-db-serverless:databases:create-database.adoc#get-db-id[database ID] of your target {astra-db} database.
+* *`APPLICATION_TOKEN`*: An xref:astra-db-serverless:administration:manage-application-tokens.adoc[application token] with a role that has the required permissions for {sstable-sideloader}, which are {create-db-permission} and {view-db-permission}.
+You can use a built-in role, such as the {database-administrator-role} role, or a xref:astra-db-serverless:administration:rbac.adoc#custom-roles[custom role] with the required permissions.
+--
 +
 [TIP]
 ====

--- a/modules/sideloader/pages/migrate-sideloader.adoc
+++ b/modules/sideloader/pages/migrate-sideloader.adoc
@@ -239,7 +239,7 @@ export token=*APPLICATION_TOKEN*
 Replace the following:
 +
 --
-*`DATABASE_ID`*: The xref:astra-db-serverless:databases:create-database.adoc#get-db-id[database ID] of your target {astra-db} database.
+* *`DATABASE_ID`*: The xref:astra-db-serverless:databases:create-database.adoc#get-db-id[database ID] of your target {astra-db} database.
 * *`APPLICATION_TOKEN`*: An xref:astra-db-serverless:administration:manage-application-tokens.adoc[application token] with a role that has the required permissions for {sstable-sideloader}, which are {create-db-permission} and {view-db-permission}.
 You can use a built-in role, such as the {database-administrator-role} role, or a xref:astra-db-serverless:administration:rbac.adoc#custom-roles[custom role] with the required permissions.
 --

--- a/modules/sideloader/pages/prepare-sideloader.adoc
+++ b/modules/sideloader/pages/prepare-sideloader.adoc
@@ -42,9 +42,14 @@ To minimize costs, you can xref:sideloader:cleanup-sideloader.adoc[manually clea
 Your target database must be an {astra-db} Serverless database.
 {sstable-sideloader} isn't compatible with {db-classic} databases.
 
-If you haven't done so already, xref:astra-db-serverless:databases:create-database.adoc[create a database].
-You can use either a {db-serverless} or {db-serverless-vector} database.
-{db-serverless-vector} databases support both fixed-schema tables and dynamic-schema collections.
+If you haven't done so already, xref:astra-db-serverless:databases:create-database.adoc[create an {astra-db} database].
+{sstable-sideloader} supports both {db-serverless} and {db-serverless-vector} databases.
+Both types support CQL tables.
+However, you must create a {db-serverless-vector} database if you want to use the xref:astra-db-serverless:api-reference:dataapiclient.adoc[{data-api}] or xref:astra-db-serverless:databases:manage-collections.adoc[dynamic-schema collections].
+
+To call the {sstable-sideloader} endpoints, you need the xref:astra-db-serverless:databases:create-database.adoc#get-db-id[database ID] and an xref:astra-db-serverless:administration:manage-application-tokens.adoc[{astra} application token] with a sufficiently privileged role.
+The required permissions for {sstable-sideloader} are {create-db-permission} and {view-db-permission}.
+You can use a built-in role, such as the {database-administrator-role} role, or a xref:astra-db-serverless:administration:rbac.adoc#custom-roles[custom role] with the required permissions.
 
 === PCU group requirement
 


### PR DESCRIPTION
* List the specific permissions required to call the sideloader endpoints and reformat the environment variable placeholder list in [Configure the target database - step 3](https://d5rxiv0do0q3v.cloudfront.net/doc-5749/data-migration/sideloader/migrate-sideloader.html#record-schema).
* In the [db type prerequisite](https://d5rxiv0do0q3v.cloudfront.net/doc-5749/data-migration/sideloader/prepare-sideloader.html#database-type-requirement), add the token and DB ID, and explain why you would use a Serverless (vector) database.